### PR TITLE
Fix TypeError: Deno.dlopen is not a function

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,8 +4,8 @@
     "start": "deno run --allow-all --unstable-ffi dist/main.esm.js",
     "dev": "deno run --allow-all --unstable-ffi --watch src/main.ts",
     "deps": "deno cache --reload --lock=deno.lock --lock-write deps.ts build.ts",
-    "build": "deno run --allow-all --allow-ffi build.ts",
-    "test": "deno test --allow-all"
+    "build": "deno run --allow-all --unstable-ffi build.ts",
+    "test": "deno test --allow-all --unstable-ffi"
   },
   "imports": {
     "std/": "https://deno.land/std@0.218.0/",


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#10](https://github.com/bramanda48/docker-mailserver-webapi/pull/10))

### Other
- TypeError: Deno.dlopen is not a function

<!--- END AUTOGENERATED NOTES --->